### PR TITLE
Fixed Robot Main

### DIFF
--- a/src/main/java/frc/robot/Main.java
+++ b/src/main/java/frc/robot/Main.java
@@ -25,6 +25,6 @@ public final class Main {
    */
   public static void main(String... args) {
     // RobotBase.startRobot(Robot::new);
-    RobotBase.startRobot(VisionTester::new);
+    RobotBase.startRobot(Robot::new);
   }
 }


### PR DESCRIPTION
Master should always use Robot in Main.java, not VisionTester.

We really should look into a way to make sure this never happened again.