### PR TITLE
Got rid of duplicate variables

### DIFF
--- a/src/main/java/frc/robot/commands/ClosedLoopAiming.java
+++ b/src/main/java/frc/robot/commands/ClosedLoopAiming.java
@@ -36,8 +36,6 @@ public class ClosedLoopAiming extends CommandBase {
   private double azimuthThreshold = 0;
 
   private double azimuthCorrection = 0.0;
-  private double accelConstant = 0.1;
-  private double azimuthThreshold = 0.0;
   private double shooterVelocity = 0.0;
   private double hoodAngle = 0.0;
   private TrajectoryConfiguration targetTrajectory;


### PR DESCRIPTION
`accelConstant` and `azimuthThreshold` were added twice in ClosedLoopAiming. If these aren't removed, `master` won't work.

Sorry to do another one of these, but this needs to be changed.