### PR TITLE
Fixed null state vision tracking bug

### DIFF
--- a/src/main/java/frc/robot/subsystems/instances/OMVPortTracker.java
+++ b/src/main/java/frc/robot/subsystems/instances/OMVPortTracker.java
@@ -121,7 +121,8 @@ public class OMVPortTracker extends OpenMVBase implements AdvancedTrackerInterfa
    * @param data
    */
   private void computeAzimuth(AdvancedTrackerInterface.AdvancedTargetData data) {
-    data.azimuth = -(centerX - data.cx) * azimuthConv;
+    if(data.cx == 0) data.azimuth = 0;
+    else data.azimuth = -(centerX - data.cx) * azimuthConv;
   }
 
   /**
@@ -129,7 +130,8 @@ public class OMVPortTracker extends OpenMVBase implements AdvancedTrackerInterfa
    * @param data
    */
   private void computeElevation(AdvancedTrackerInterface.AdvancedTargetData data) {
-    data.elevation = (centerY - data.cy) * elevationConv + baseElev;
+    if(data.cy == 0) data.elevation = 0;
+    else data.elevation = (centerY - data.cy) * elevationConv + baseElev;
   }
 
    /**

--- a/src/main/java/frc/robot/subsystems/instances/OMVPortTracker.java
+++ b/src/main/java/frc/robot/subsystems/instances/OMVPortTracker.java
@@ -121,7 +121,7 @@ public class OMVPortTracker extends OpenMVBase implements AdvancedTrackerInterfa
    * @param data
    */
   private void computeAzimuth(AdvancedTrackerInterface.AdvancedTargetData data) {
-    if(data.cx == 0) data.azimuth = 0;
+    if(data.quality == 0) data.azimuth = 0;
     else data.azimuth = -(centerX - data.cx) * azimuthConv;
   }
 
@@ -130,7 +130,7 @@ public class OMVPortTracker extends OpenMVBase implements AdvancedTrackerInterfa
    * @param data
    */
   private void computeElevation(AdvancedTrackerInterface.AdvancedTargetData data) {
-    if(data.cy == 0) data.elevation = 0;
+    if(data.quality == 0) data.elevation = 0;
     else data.elevation = (centerY - data.cy) * elevationConv + baseElev;
   }
 


### PR DESCRIPTION
Pull Request Checklist:
- [x] You are able to understand what the code is doing on a basic level with the use of comments
- [x] Code is formatted in a way that isn't confusing
- [x] builds cleanly
- [x] builds *to the robot* cleanly
- [x] Code has been tested on the robot/roadkill/other mechanical setup and completes the task it needs to complete

Because the default for bytearrays in python makes each value 0, the java side (in OMVPortTracker) interprets this as the target being all the way to the left of the screen even when there is no target. This commit is one option to fix this bug. Alternatively, we could make the default values for the target bytearray something different on the OpenMV side.